### PR TITLE
Add support for MediaBox PDF parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ usage: boxer
  -artBox <arg>       Sets the ArtBox. Must be passed as x,y,width,height
  -bleedBox <arg>     Sets the BleedBox. Must be passed as x,y,width,height
  -cropBox <arg>      Sets the CropBox. Must be passed as x,y,width,height
+ -mediaBox <arg>     Sets the MediaBox. Must be passed as x,y,width,height
  -sourceFile <arg>   The source pdf
  -destFile <arg>     The destination pdf
 ```

--- a/src/main/java/com/nickdsantos/pdfboxer/Boxer.java
+++ b/src/main/java/com/nickdsantos/pdfboxer/Boxer.java
@@ -52,6 +52,10 @@ public class Boxer {
 		changeMap.put("BleedBox", new PDRectangle(x, y, w, h));
 	}
 
+	public void setMediaBox(float x, float y, float w, float h) {
+		changeMap.put("MediaBox", new PDRectangle(x, y, w, h));
+	}
+
 	public void save() throws IOException {
 		PDPageTree pages = doc.getPages();
 		for (int i = 0; i < pages.getCount(); i++) {
@@ -75,6 +79,9 @@ public class Boxer {
 					break;
 				case "BleedBox":
 					p.setBleedBox(rect);
+					break;
+				case "MediaBox":
+					p.setMediaBox(rect);
 					break;
 				}
 			}

--- a/src/main/java/com/nickdsantos/pdfboxer/BoxerCmd.java
+++ b/src/main/java/com/nickdsantos/pdfboxer/BoxerCmd.java
@@ -29,6 +29,10 @@ public class BoxerCmd {
 				.desc("Sets the CropBox. Must be passed as x,y,width,height")
 				.build();
 
+		Option mediaBoxOpt = Option.builder("mediaBox").hasArg()
+				.desc("Sets the MediaBox. Must be passed as x,y,width,height")
+				.build();
+
 		Option sourceFileOpt = Option.builder("sourceFile").hasArg().required()
 				.desc("The source pdf").build();
 
@@ -40,6 +44,7 @@ public class BoxerCmd {
 		options.addOption(artBoxOpt);
 		options.addOption(bleedBoxOpt);
 		options.addOption(cropBoxOpt);
+		options.addOption(mediaBoxOpt);
 		options.addOption(sourceFileOpt);
 		options.addOption(destFileOpt);
 
@@ -50,6 +55,7 @@ public class BoxerCmd {
 		String[] artBoxVal = null;
 		String[] bleedBoxVal = null;
 		String[] cropBoxVal = null;
+		String[] mediaBoxVal = null;
 		Boxer boxer = null;
 
 		try {
@@ -62,7 +68,7 @@ public class BoxerCmd {
 			}
 
 			if (cmdLine.hasOption("artBox")) {
-				artBoxVal = cmdLine.getOptionValue("trimBox").split(",", -1);
+				artBoxVal = cmdLine.getOptionValue("artBox").split(",", -1);
 			}
 
 			if (cmdLine.hasOption("bleedBox")) {
@@ -71,6 +77,10 @@ public class BoxerCmd {
 
 			if (cmdLine.hasOption("cropBox")) {
 				cropBoxVal = cmdLine.getOptionValue("cropBox").split(",", -1);
+			}
+
+			if (cmdLine.hasOption("mediaBox")) {
+				mediaBoxVal = cmdLine.getOptionValue("mediaBox").split(",", -1);
 			}
 
 			sourceFileVal = cmdLine.getOptionValue("sourceFile");
@@ -118,6 +128,12 @@ public class BoxerCmd {
 					Float.parseFloat(cropBoxVal[3]));
 		}
 
+		if (mediaBoxVal != null) {
+			boxer.setMediaBox(Float.parseFloat(mediaBoxVal[0]),
+					Float.parseFloat(mediaBoxVal[1]),
+					Float.parseFloat(mediaBoxVal[2]),
+					Float.parseFloat(mediaBoxVal[3]));
+		}
 		try {
 			boxer.save();
 		} catch (IOException e) {


### PR DESCRIPTION
See PDF spec, it defines 5 Box types:
MediaBox
CropBox
BleedBox
TrimBox
ArtBox

pdfboxer already supported 4, but MediaBox was missing. This change adds that one. 

Command line values for ArtBox seems to be have been taken from wrong command line parameter. Fixed that as well. 